### PR TITLE
Proper way to get the ZeeWorkflow to run

### DIFF
--- a/packages/create-zee-app/templates/001-zee-barebones/src/index.ts
+++ b/packages/create-zee-app/templates/001-zee-barebones/src/index.ts
@@ -26,6 +26,6 @@ const zee = new ZeeWorkflow({
 });
 
 (async function main() {
-    const result = await zee.run();
+    const result = await ZeeWorkflow.run(zee);
     console.log(result);
 })();


### PR DESCRIPTION
Previously, we were trying to invoke `zee.run()` (where `zee` is instance of `ZeeWorkflow`).

However, instances of `ZeeWorklfow` does not have a method called `run`. However, `ZeeWorkflow` itself has a static method called `run` and accepts an instance of `ZeeWorkflow` as its first parameter.
