### PR TITLE
doc: fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const zee = new ZeeWorkflow({
 
 ```js
 (async function main() {
-    const result = await zee.run();
+    const result = await ZeeWorkflow.run(zee);
     console.log(result);
 })();
 ```

--- a/docs/concepts/agents.mdx
+++ b/docs/concepts/agents.mdx
@@ -45,7 +45,7 @@ Read more about [Tools](/concepts/tools) to learn how to create them.
 Agents can be run standalone or as part of a ZEE workflow. Running an agent standalone is useful for testing and debugging. The `run` method will return the final state of the agent.
 
 ```typescript
-const result = await agent.run();
+const result = await agent.run(state);
 ```
 
 Running an agent as part of a ZEE workflow is useful for solving complex problems. Read more about [ZEE](/concepts/zeeworkflows) to learn how to run agents in a ZEE workflow.


### PR DESCRIPTION
- fix readme `zee.run();`, it is deprecated
- `agent.run();` is deprecated too, it should take the `state`
   However, the `StateFn`  is not exported now: https://github.com/covalenthq/ai-agent-sdk/blob/main/packages/ai-agent-sdk/src/index.ts
   Should we also export 
   ```ts
   export * from "./core/base";
   export * from "./core/state";
   ```
   as well?