### PR TITLE
feat: Add dynamic zee maxIterations

### DIFF
--- a/packages/ai-agent-sdk/src/core/zee/index.ts
+++ b/packages/ai-agent-sdk/src/core/zee/index.ts
@@ -8,6 +8,7 @@ type ZeeWorkflowOptions = {
     description: string;
     output: string;
     agents: Record<AgentName, Agent>;
+    maxIterations?: number;
 };
 
 const runTools = async (
@@ -57,6 +58,7 @@ const execute = async (
         return StateFn.childState({
             ...state,
             agent: "finalBoss",
+            status: state.status == "running" ? "paused" : state.status,
         });
     }
 
@@ -133,7 +135,8 @@ export class ZeeWorkflow extends Base {
     }
 
     get maxIterations() {
-        return 50;
+        const maxIterations = this.config.maxIterations;
+        return maxIterations > 0 ? maxIterations : 50;
     }
 
     agent(agentName: string): Agent {


### PR DESCRIPTION
Related to #49 

- Add `maxIterations` in the constructor, and fallback to `50` as its previously defined if `maxIterations` is not given
- Only use the passed `maxIterations` when its greater than 0, other than that will use the fallback value
- Override the state status of `running` into `paused` when the messages length surpassed `maxIterations` 
- Added unit testing for `maxIterations`