### PR TITLE
Gradio plugin integration to covalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const zee = new ZeeWorkflow({
 })();
 ```
 
+### Refer Configs for other SDK's Integrations like Hugging face, Gemini, Gradio etc. on [llms.mdx Readme File](https://github.com/covalenthq/ai-agent-sdk/blob/main/docs/concepts/llms.mdx)
 ## 🤝 Contributing
 
 Contributions, issues and feature requests are welcome!

--- a/docs/concepts/llms.mdx
+++ b/docs/concepts/llms.mdx
@@ -45,6 +45,10 @@ const llm = new LLM({
 "gemini-1.5-pro"
 ```
 
+```plaintext Gradio
+"Any Supported and hosted inference and generation algorithms using gradio python library"
+```
+
 </CodeGroup>
 
 ## Environment Variables
@@ -68,6 +72,73 @@ GEMINI_API_KEY
 ```
 
 </CodeGroup>
+
+## Example Usage:
+
+For deepseek-ai/deepseek-vl2-small:
+
+```typescript
+const gradioConfig: GradioConfig = {
+    provider: "GRADIO",
+    name: "deepseek-vl2-small",
+    appUrl: "deepseek-ai/deepseek-vl2-small",
+    parameters: [
+        [["Hello!", null]],
+        0.9, // topP
+        0.1, // temperature
+        0, // repetitionPenalty
+        100, // maxGenerationTokens
+        0, // maxHistoryTokens
+        "deepseek-ai/deepseek-vl2-small", // model name
+    ],
+};
+
+const llm = new LLM(gradioConfig);
+const response = await llm.generate(
+    [{ role: "user", content: "Hello!" }],
+    { text: z.string() },
+    {}
+);
+console.log(response.value);
+```
+For r3gm/RVC_HF:
+```typescript
+const gradioConfig: GradioConfig = {
+    provider: "GRADIO",
+    name: "RVC_HF",
+    appUrl: "r3gm/RVC_HF",
+    endpoint: "/run_infer_script",
+    parameters: {
+        f0up_key: 0,
+        filter_radius: 5,
+        index_rate: 0,
+        rms_mix_rate: 0,
+        protect: 0,
+        hop_length: 1,
+        f0method: "rmvpe",
+        input_path: "https://raw.githubusercontent.com/Philotheephilix/Tunify/main/public/amidreaming.wav",
+        output_path: "/home/user/app/assets/audios/output.wav",
+        pth_path: "logs/Justin_Bieber_v2/Justin_Bieber_v2.pth",
+        index_path: "logs/Justin_Bieber_v2/added_IVF1005_Flat_nprobe_1_Justin_Bieber_v2_v2.index",
+        clean_strength: 0,
+        export_format: "WAV",
+        embedder_model: "hubert",
+        embedder_model_custom: "",
+        upscale_audio: true,
+    },
+};
+```
+Gradio is used for custom made inference and algorithms so the working depends solely on the developer of the Gradio Project and the api configured for it.
+
+### Initialization example with Gradio
+
+const llm = new LLM(gradioConfig);
+const response = await llm.generate(
+    [], // Messages not used for this model
+    { result: z.string() },
+    {}
+);
+console.log(response.value);
 
 ## Use Cases
 

--- a/packages/ai-agent-sdk/package.json
+++ b/packages/ai-agent-sdk/package.json
@@ -49,6 +49,7 @@
     },
     "dependencies": {
         "@covalenthq/client-sdk": "^2.2.3",
+        "@gradio/client": "^1.11.0",
         "commander": "^13.1.0",
         "dotenv": "^16.4.7",
         "openai": "^4.79.1",

--- a/packages/ai-agent-sdk/src/core/llm/llm.types.ts
+++ b/packages/ai-agent-sdk/src/core/llm/llm.types.ts
@@ -47,11 +47,21 @@ export type GeminiConfig = {
     apiKey?: string;
 };
 
+export type GradioConfig = {
+    provider: "GRADIO";
+    name: string;
+    appUrl: string;
+    endpoint?: string;
+    parameters?: unknown[];
+    apiKey?: string;
+};
+
 export type ModelConfig =
     | OpenAIConfig
     | DeepSeekConfig
     | GrokConfig
-    | GeminiConfig;
+    | GeminiConfig
+    | GradioConfig;
 
 export type LLMResponse<T extends Record<string, AnyZodObject>> = {
     [K in keyof T]: {
@@ -63,4 +73,18 @@ export type LLMResponse<T extends Record<string, AnyZodObject>> = {
 export type FunctionToolCall = {
     type: "tool_call";
     value: ParsedFunctionToolCall[];
+};
+
+export type ChatCompletionMessageParam = {
+    role: "user" | "assistant" | "system";
+    content: string;
+};
+
+export type ChatCompletionTool = {
+    type: "function";
+    function: {
+        name: string;
+        description?: string;
+        parameters: Record<string, unknown>;
+    };
 };

--- a/packages/ai-agent-sdk/src/core/llm/llm.types.ts
+++ b/packages/ai-agent-sdk/src/core/llm/llm.types.ts
@@ -53,6 +53,7 @@ export type GradioConfig = {
     appUrl: string;
     endpoint?: string;
     parameters?: unknown[];
+    temperature?: number; 
     apiKey?: string;
 };
 


### PR DESCRIPTION
Gradio is a well known UI / API library in Python
It is mostly used for handling models for inferencing , generation of complex images, other algorithm focusing on any need from basic flask like app to fully working voice model generator

## Integration
- SDK integration with minimal code changes
- added proper types in type file and reused response handling 

## Motivation for Contribution
-  I am using covalent with gradio hosted on Hugging face on AGENTIC ETHEREUM hackathon conducted by ETHGLOBAL
- As i am already used to Covalent's Gold Rush API on Build On hackathon i felt like contributing to covalent